### PR TITLE
Muda a lógica da migração de dados da tabela de rastremento

### DIFF
--- a/mapcon/pages/api/mapcon/crawling_news.ts
+++ b/mapcon/pages/api/mapcon/crawling_news.ts
@@ -11,7 +11,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
             res.status(200).json(await base.getModel('crawling.crawling_news', { 'url': req.query.id }))
         } else if (req.method == 'GET') {     
             res.status(200).json(await base.getModels('crawling.crawling_news', req.query))
-        } else if (req.method == 'PUT'){
+        } else if (req.method == 'PUT') {
             res.status(200).json(await base.updateModel('crawling.crawling_news',{ 'url': req.body.url },req.body))
         } else if (req.method == 'DELETE'){
             res.status(200).json(await base.deleteModel('crawling.crawling_news',{ 'url': req.body.url }))

--- a/mapcon/styles/globals.css
+++ b/mapcon/styles/globals.css
@@ -22,7 +22,7 @@
 }
 
 
-*{
+* {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   margin: 0px;
   text-decoration: none;
@@ -33,7 +33,7 @@ a{
 }
 
 .p-component, .p-inputtext {
-  font-size: 12px !important;
+  font-size: 0.85rem !important;
 }
 
 .p-card-content{


### PR DESCRIPTION
## Descrição
Ao migrar uma notícia o sistema agora não remove esta da tabela de rastreamento, apenas atualiza-a como processada e sendo protesto (ou não).

Fixes #3 #24